### PR TITLE
Add PDF export option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rich-CLI now assumes that the input file is encoded in UTF-8 https://github.com/Textualize/rich-cli/pull/56
 
+### Added
+
+- Added `--export-pdf` option
+
 ## [1.8.0] - 2022-05-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -167,13 +167,17 @@ rich https://raw.githubusercontent.com/Textualize/rich-cli/main/README.md --mark
 
 ## Exporting
 
-In addition to rendering to the console, `rich` can write an HTML file. This works with any command. Add `--export-html` or `-o` followed by the output path.
+In addition to rendering to the console, `rich` can write an HTML file. This works with any command. Add `--export-html` or `-o` followed by the output path. You can also export to PDF with `--export-pdf` and a file name.
 
 ```
 rich README.md -o readme.html
 ```
 
-After running this command you should find a "readme.html" in your current working directory.
+After running this command you should find a "readme.html" in your current working directory. To save a PDF, run:
+
+```
+rich README.md --export-pdf readme.pdf
+```
 
 ## Rich Printing
 

--- a/src/rich_cli/__main__.py
+++ b/src/rich_cli/__main__.py
@@ -395,6 +395,9 @@ class RichCommand(click.Command):
 @click.option(
     "--export-svg", metavar="PATH", default="", help="Write SVG to [b]PATH[/b]."
 )
+@click.option(
+    "--export-pdf", metavar="PATH", default="", help="Write PDF to [b]PATH[/b]."
+)
 @click.option("--pager", is_flag=True, help="Display in an interactive pager.")
 @click.option("--version", "-v", is_flag=True, help="Print version and exit.")
 def main(
@@ -440,6 +443,7 @@ def main(
     force_terminal: bool = False,
     export_html: str = "",
     export_svg: str = "",
+    export_pdf: str = "",
     pager: bool = False,
 ):
     """Rich toolbox for console output."""
@@ -448,7 +452,7 @@ def main(
         return
     console = Console(
         emoji=emoji,
-        record=bool(export_html or export_svg),
+        record=bool(export_html or export_svg or export_pdf),
         force_terminal=force_terminal if force_terminal else None,
     )
 
@@ -731,6 +735,12 @@ def main(
             console.save_svg(export_svg, clear=False)
         except Exception as error:
             on_error("failed to save SVG", error)
+
+    if export_pdf:
+        try:
+            console.save_pdf(export_pdf, clear=False)
+        except Exception as error:
+            on_error("failed to save PDF", error)
 
 
 def render_csv(


### PR DESCRIPTION
## Summary
- add `--export-pdf` option to save console output
- document new option in README
- note new option in changelog

## Testing
- `python -m py_compile src/rich_cli/__main__.py`